### PR TITLE
style: add shared styles for policy and stock pages

### DIFF
--- a/bookhub-front/src/styles/style.css
+++ b/bookhub-front/src/styles/style.css
@@ -315,3 +315,59 @@ th, td {
     margin-right: 10px;
     font-size: 16px;
 }
+
+/* Common layouts for policy, publisher, stock and stock-log pages */
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.table-policy {
+    width: 100%;
+    margin: 16px auto;
+    border-collapse: collapse;
+    background-color: white;
+}
+
+.table-policy thead tr {
+    background-color: #2b5480;
+    color: white;
+}
+
+.table-policy th,
+.table-policy td {
+    border: 1px solid #eee;
+    padding: 12px;
+    text-align: center;
+    font-size: 14px;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.pagination button {
+    background-color: #265185;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+.pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.pagination span {
+    margin: 0 8px;
+    font-size: 14px;
+}

--- a/bookhub-front/src/views/policy/PolicySearch.tsx
+++ b/bookhub-front/src/views/policy/PolicySearch.tsx
@@ -4,6 +4,7 @@ import { PolicyDetailResponseDto, PolicyListResponseDto } from "@/dtos/policy/Po
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import PolicyDetail from "./PolicyDetail";
+import "@/styles/style.css";
 
 const PAGE_SIZE = 10;
 

--- a/bookhub-front/src/views/publisher/Publisherpage.tsx
+++ b/bookhub-front/src/views/publisher/Publisherpage.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react'
 import { useCookies } from 'react-cookie';
 import Createpublisher from './Createpublisher';
 import UpdatePublisher from './UpdatePublisher';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 

--- a/bookhub-front/src/views/stock-logs/StockLogPage.tsx
+++ b/bookhub-front/src/views/stock-logs/StockLogPage.tsx
@@ -5,6 +5,7 @@ import { StockProps } from '@/components/types/StockProps';
 import StockLogdetail from './StockLogdetail';
 import { useCookies } from 'react-cookie';
 import { useEffect, useState } from 'react';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -89,7 +90,7 @@ function StockLogPage({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 로그</h2>
-      <div>
+      <div className='filter-bar'>
         <select className='input-search' value={type} onChange={(e) => setType(e.target.value as StockActionType)}>
           <option value=''>전체</option>
           <option value={StockActionType.IN}>입고</option>
@@ -127,7 +128,7 @@ function StockLogPage({ branches = [] }: StockProps) {
           검색
         </button>
         <div>
-          <table className=''>
+          <table className='table-policy'>
             <thead>
               <tr>
                 <th>IDX</th>
@@ -149,7 +150,7 @@ function StockLogPage({ branches = [] }: StockProps) {
                   <td>{s.amount}</td>
                   <td>{s.type}</td>
                   <td>
-                    <button className='' onClick={() => openDetailModal(s.stockLogId)}>
+                    <button className='modifyBtn' onClick={() => openDetailModal(s.stockLogId)}>
                       보기
                     </button>
                   </td>

--- a/bookhub-front/src/views/stocks/StockPage.tsx
+++ b/bookhub-front/src/views/stocks/StockPage.tsx
@@ -4,6 +4,7 @@ import { StockResponseDto } from '@/dtos/stock/Stock.response.dto';
 import { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import StockUpdate from './StockUpdate';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -100,7 +101,7 @@ function StockPage({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 관리</h2>
-      <div className=''>
+      <div className='filter-bar'>
         <input
           className='input-search'
           type='text'

--- a/bookhub-front/src/views/stocks/StockSearch.tsx
+++ b/bookhub-front/src/views/stocks/StockSearch.tsx
@@ -4,6 +4,7 @@ import { StockResponseDto } from '@/dtos/stock/Stock.response.dto';
 import { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import StockDetail from './StockDetail';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -86,7 +87,7 @@ function StockSearch({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 검색</h2>
-      <div className=''>
+      <div className='filter-bar'>
         <input
           className='input-search'
           type='text'


### PR DESCRIPTION
## Summary
- style: add shared style rules for policy, publisher, stock and stock-log views
- chore: import shared stylesheet in related pages

## Testing
- `npm run lint`
- `npm run build` *(fails: 'React' is declared but its value is never read, etc. in statistics files)*

------
https://chatgpt.com/codex/tasks/task_e_68917f8ae810832794d93bcbf3d2bacc