### PR TITLE
style: replace modal css modules with global stylesheet

### DIFF
--- a/bookhub-front/src/styles/modal.css
+++ b/bookhub-front/src/styles/modal.css
@@ -1,0 +1,90 @@
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalContainer {
+  background-color: #fff;
+  border-radius: 6px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  max-width: 600px;
+  width: 100%;
+  padding: 1.5rem 2rem;
+  position: relative;
+}
+
+.modalCloseButton {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  color: #888;
+  cursor: pointer;
+}
+
+.modalCloseButton:hover {
+  color: #e74c3c;
+}
+
+.modalTitle {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #305882;
+}
+
+.detailTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.detailTable th,
+.detailTable td {
+  border: 1px solid #eee;
+  padding: 8px;
+  text-align: center;
+}
+
+.errorMessage {
+  color: #e74c3c;
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+  gap: 0.75rem;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.twoCols {
+  display: flex;
+  gap: 1rem;
+}
+
+.formGroup input,
+.formGroup textarea,
+.formGroup select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/bookhub-front/src/styles/style.css
+++ b/bookhub-front/src/styles/style.css
@@ -315,3 +315,59 @@ th, td {
     margin-right: 10px;
     font-size: 16px;
 }
+
+/* Common layouts for policy, publisher, stock and stock-log pages */
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.table-policy {
+    width: 100%;
+    margin: 16px auto;
+    border-collapse: collapse;
+    background-color: white;
+}
+
+.table-policy thead tr {
+    background-color: #2b5480;
+    color: white;
+}
+
+.table-policy th,
+.table-policy td {
+    border: 1px solid #eee;
+    padding: 12px;
+    text-align: center;
+    font-size: 14px;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.pagination button {
+    background-color: #265185;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+
+.pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.pagination span {
+    margin: 0 8px;
+    font-size: 14px;
+}

--- a/bookhub-front/src/views/policy/CreatePolicy.tsx
+++ b/bookhub-front/src/views/policy/CreatePolicy.tsx
@@ -3,6 +3,7 @@ import { createPolicy } from "@/apis/policies/PolicyAdmin";
 import { PolicyCreateRequestDto } from "@/dtos/policy/Policy.request.dto";
 import { useState } from "react";
 import { useCookies } from "react-cookie";
+import '@/styles/modal.css';
 
 interface CreatePolicyProps{
     isOpen: boolean;
@@ -70,11 +71,11 @@ function CreatePolicy({isOpen, onClose, onCreated}:CreatePolicyProps){
     if(!isOpen) return null;
 
     return(
-        <div className="modal-overlay">
-            <div className="policy-detail-modal">
-                <button className="modal-close-button" onClick={onClose}>x</button>
-                <h2 className="modal-title">정책 등록</h2>
-                <div className="form-group">
+        <div className="modalOverlay">
+            <div className="modalContainer">
+                <button className="modalCloseButton" onClick={onClose}>x</button>
+                <h2 className="modalTitle">정책 등록</h2>
+                <div className="formGroup">
                     <label>정책 타입</label>
                     <select value={policyType} onChange={e=>setPolicyType(e.target.value as PolicyType)}>
                         <option value={PolicyType.BOOK_DISCOUNT}>도서 할인</option>
@@ -82,7 +83,7 @@ function CreatePolicy({isOpen, onClose, onCreated}:CreatePolicyProps){
                         <option value={PolicyType.TOTAL_PRICE_DISCOUNT}>총 금액 할인</option>
                     </select>
                 </div>
-                <div className="form-group two-cols">
+                <div className="formGroup twoCols">
                     <div>
                         <label>시작일</label>
                         <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}/>
@@ -93,34 +94,33 @@ function CreatePolicy({isOpen, onClose, onCreated}:CreatePolicyProps){
                     </div>
                 </div>
 
-                <div className="form-group">
+                <div className="formGroup">
                     <label>제목</label>
-                    <input type="text" placeholder="정책 제목을 입력하세요" value={policyTitle} 
+                    <input type="text" placeholder="정책 제목을 입력하세요" value={policyTitle}
                     onChange={e => setPolicyTitle(e.target.value)}/>
                 </div>
 
-                <div className="form-group">
+                <div className="formGroup">
                     <label>설명</label>
-                    <textarea placeholder="정책 설명을 입력하세요" value={policyDescription} 
+                    <textarea placeholder="정책 설명을 입력하세요" value={policyDescription}
                     onChange={e => setPolicyDescription(e.target.value)}/>
                 </div>
 
-                <div className="form-group two-cols">
+                <div className="formGroup twoCols">
                     <div>
                         <label>총 금액</label>
-                        <input type="number" placeholder="총 금액" value={totalPriceAchieve ?? ''} 
+                        <input type="number" placeholder="총 금액" value={totalPriceAchieve ?? ''}
                         onChange={e =>setTotalPriceAchieve(e.target.value ? Number(e.target.value) : undefined)} />
                     </div>
-
                     <div>
                         <label>할인율(%)</label>
-                        <input type="number" placeholder="할인율(%)" value={discountPercent ?? ''} 
+                        <input type="number" placeholder="할인율(%)" value={discountPercent ?? ''}
                         onChange={e =>setDiscountPercent(Number(e.target.value))} />
                     </div>
                 </div>
 
-                {message && <p className="error-message">{message}</p>}
-                <div className="modal-footer">
+                {message && <p className="errorMessage">{message}</p>}
+                <div className="modalFooter">
                     <button onClick={onCreateClick} className="">등록</button>
                 </div>
 

--- a/bookhub-front/src/views/policy/PolicyDetail.tsx
+++ b/bookhub-front/src/views/policy/PolicyDetail.tsx
@@ -1,5 +1,6 @@
 import { PolicyType } from '@/apis/enums/PolicyType';
 import { PolicyDetailResponseDto } from '@/dtos/policy/Policy.response.dto';
+import '@/styles/modal.css';
 
 interface PolicyDetailProps {
     isOpen: boolean;
@@ -12,11 +13,11 @@ function PolicyDetail({isOpen, onClose, policyDetail}:PolicyDetailProps) {
   if(!isOpen) return null;
 
   return (
-    <div className="modal-overlay">
-        <div className="policy-detail-modal">
-            <button className="modal-close-button" onClick={onClose}>x</button>
-            <h2 className="modal-title">정책 상세 조회</h2>
-            <table className="detail-table">
+    <div className="modalOverlay">
+        <div className="modalContainer">
+            <button className="modalCloseButton" onClick={onClose}>x</button>
+            <h2 className="modalTitle">정책 상세 조회</h2>
+            <table className="detailTable">
                 <tbody>
                     <tr>
                         <th>제목</th>

--- a/bookhub-front/src/views/policy/PolicySearch.tsx
+++ b/bookhub-front/src/views/policy/PolicySearch.tsx
@@ -4,6 +4,7 @@ import { PolicyDetailResponseDto, PolicyListResponseDto } from "@/dtos/policy/Po
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import PolicyDetail from "./PolicyDetail";
+import "@/styles/style.css";
 
 const PAGE_SIZE = 10;
 

--- a/bookhub-front/src/views/policy/UpdatePolicy.tsx
+++ b/bookhub-front/src/views/policy/UpdatePolicy.tsx
@@ -1,11 +1,10 @@
-
-
 import { PolicyType } from '@/apis/enums/PolicyType';
 import { updatePolicy } from '@/apis/policies/PolicyAdmin';
 import { PolicyUpdateRequestDto } from '@/dtos/policy/Policy.request.dto';
 import { PolicyDetailResponseDto } from '@/dtos/policy/Policy.response.dto';
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
+import '@/styles/modal.css';
 
 interface UpdatePolicyProps {
     isOpen: boolean;
@@ -16,7 +15,6 @@ interface UpdatePolicyProps {
 }
 
 function UpdatePolicy({ isOpen, onClose, onUpdate, policyDetail, policyId }: UpdatePolicyProps) {
-
     const [cookies] = useCookies(['accessToken']);
     const token = cookies.accessToken;
     const [policyTitle, setPolicyTitle] = useState('');
@@ -63,83 +61,80 @@ function UpdatePolicy({ isOpen, onClose, onUpdate, policyDetail, policyId }: Upd
             endDate
         };
 
-        try{
-            const response = await updatePolicy(policyId,dto,token);
-            if(response.code !=='SU'){
-            setMessage(response.message || '수정 실패');
-            return;
+        try {
+            const response = await updatePolicy(policyId, dto, token);
+            if (response.code !== 'SU') {
+                setMessage(response.message || '수정 실패');
+                return;
             }
             alert('정책이 성공적으로 수정되었습니다');
             onUpdate();
             onClose();
-        }catch(err){
-            console.error('정책 수정 중 예외',err);
+        } catch (err) {
+            console.error('정책 수정 중 예외', err);
             setMessage('정책 수정 중 예외 발생');
         }
     };
 
-    if(!isOpen) return null;
-
+    if (!isOpen) return null;
 
     return (
-        <div className="modal-overlay">
-            <div className="policy-detail-modal">
-                <button className="modal-close-button" onClick={onClose}>x</button>
-                <h2 className="modal-title">정책 수정</h2>
-                <div className="form-group">
+        <div className="modalOverlay">
+            <div className="modalContainer">
+                <button className="modalCloseButton" onClick={onClose}>x</button>
+                <h2 className="modalTitle">정책 수정</h2>
+                <div className="formGroup">
                     <label>정책 타입</label>
-                    <select value={policyType} onChange={e=>setPolicyType(e.target.value as PolicyType)}>
+                    <select value={policyType} onChange={e => setPolicyType(e.target.value as PolicyType)}>
                         <option value={PolicyType.BOOK_DISCOUNT}>도서 할인</option>
                         <option value={PolicyType.CATEGORY_DISCOUNT}>카테고리 할인</option>
                         <option value={PolicyType.TOTAL_PRICE_DISCOUNT}>총 금액 할인</option>
                     </select>
                 </div>
-                <div className="form-group two-cols">
+                <div className="formGroup twoCols">
                     <div>
                         <label>시작일</label>
-                        <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}/>
+                        <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
                     </div>
                     <div>
                         <label>종료일</label>
-                        <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)}/>
+                        <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
                     </div>
                 </div>
 
-                <div className="form-group">
+                <div className="formGroup">
                     <label>제목</label>
-                    <input type="text" placeholder="정책 제목을 입력하세요" value={policyTitle} 
-                    onChange={e => setPolicyTitle(e.target.value)}/>
+                    <input type="text" placeholder="정책 제목을 입력하세요" value={policyTitle}
+                        onChange={e => setPolicyTitle(e.target.value)} />
                 </div>
 
-                <div className="form-group">
+                <div className="formGroup">
                     <label>설명</label>
-                    <textarea placeholder="정책 설명을 입력하세요" value={policyDescription} 
-                    onChange={e => setPolicyDescription(e.target.value)}/>
+                    <textarea placeholder="정책 설명을 입력하세요" value={policyDescription}
+                        onChange={e => setPolicyDescription(e.target.value)} />
                 </div>
 
-                <div className="form-group two-cols">
+                <div className="formGroup twoCols">
                     <div>
                         <label>총 금액</label>
-                        <input type="number" placeholder="총 금액" value={totalPriceAchieve ?? ''} 
-                        onChange={e =>setTotalPriceAchieve(e.target.value ? Number(e.target.value) : undefined)} />
+                        <input type="number" placeholder="총 금액" value={totalPriceAchieve ?? ''}
+                            onChange={e => setTotalPriceAchieve(e.target.value ? Number(e.target.value) : undefined)} />
                     </div>
 
                     <div>
                         <label>할인율(%)</label>
-                        <input type="number" placeholder="할인율(%)" value={discountPercent} 
-                        onChange={e =>setDiscountPercent(Number(e.target.value))} />
+                        <input type="number" placeholder="할인율(%)" value={discountPercent}
+                            onChange={e => setDiscountPercent(Number(e.target.value))} />
                     </div>
                 </div>
 
-                {message && <p className="error-message">{message}</p>}
-                <div className="modal-footer">
-                    <button onClick={onUpdateClick} className="">수정</button>
+                {message && <p className="errorMessage">{message}</p>}
+                <div className="modalFooter">
+                    <button onClick={onUpdateClick} className=''>수정</button>
                 </div>
-
             </div>
-
         </div>
-    )
+    );
 }
 
-export default UpdatePolicy
+export default UpdatePolicy;

--- a/bookhub-front/src/views/publisher/Createpublisher.tsx
+++ b/bookhub-front/src/views/publisher/Createpublisher.tsx
@@ -1,14 +1,14 @@
 import { createPublisher } from '@/apis/publisher/publisher';
 import { PublisherRequestDto } from '@/dtos/publishers/publisher.request.dto';
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 import { useCookies } from 'react-cookie';
+import '@/styles/modal.css';
 
 interface CreatePublisherProps{
     isOpen: boolean;
     onClose : () => void;
     onCreated : () => void;
 }
-
 
 function Createpublisher({isOpen, onClose, onCreated}:CreatePublisherProps
 
@@ -44,21 +44,21 @@ function Createpublisher({isOpen, onClose, onCreated}:CreatePublisherProps
         onClose();
         setPublisherName('');
         setMessage('');
-        
+
       };
       if(!isOpen) return null
   return (
-    <div className='modal'>
-      <div><button className="modal-close-button" onClick={onClose}>x</button>
-      <h2 className='modal-title'>출판사 등록</h2>
-      <div><input type="text" value={publisherName} onChange={e => setPublisherName(e.target.value)} /></div>
-      {message && <p className="error-message">{message}</p>}
-      <div className="modal-footer">
-                    <button onClick={onCreateClick} className="">등록</button>
-                </div>
-      
-      </div></div>
+      <div className="modalOverlay">
+        <div className="modalContainer"><button className="modalCloseButton" onClick={onClose}>x</button>
+        <h2 className="modalTitle">출판사 등록</h2>
+        <div className="formGroup"><input type="text" value={publisherName} onChange={e => setPublisherName(e.target.value)} /></div>
+        {message && <p className="errorMessage">{message}</p>}
+        <div className="modalFooter">
+                      <button onClick={onCreateClick} className="">등록</button>
+                  </div>
+
+        </div></div>
   )
 }
 
-export default Createpublisher
+export default Createpublisher;

--- a/bookhub-front/src/views/publisher/Publisherpage.tsx
+++ b/bookhub-front/src/views/publisher/Publisherpage.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react'
 import { useCookies } from 'react-cookie';
 import Createpublisher from './Createpublisher';
 import UpdatePublisher from './UpdatePublisher';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 

--- a/bookhub-front/src/views/publisher/UpdatePublisher.tsx
+++ b/bookhub-front/src/views/publisher/UpdatePublisher.tsx
@@ -1,8 +1,9 @@
 import { updatePublisher } from '@/apis/publisher/publisher';
 import { PublisherRequestDto } from '@/dtos/publishers/publisher.request.dto';
 import { PublisherResponseDto } from '@/dtos/publishers/publisher.response.dto';
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
+import '@/styles/modal.css';
 
 interface UpdatePublisherProps {
     isOpen: boolean;
@@ -57,19 +58,18 @@ function UpdatePublisher({isOpen, onClose, onUpdate, publisherDetail, publisherI
 
     if(!isOpen) return null;
 
-    
-  return (
-    <div className='modal'>
-      <div><button className="modal-close-button" onClick={onClose}>x</button>
-      <h2 className='modal-title'>출판사 수정</h2>
-      <div><input type="text" value={publisherName} onChange={e => setPublisherName(e.target.value)} /></div>
-      {message && <p className="error-message">{message}</p>}
-      <div className="modal-footer">
-                    <button onClick={onUpdateClick} className="">수정</button>
-                </div>
-      
-      </div></div>
-  )
-}
+      return (
+        <div className="modalOverlay">
+          <div className="modalContainer"><button className="modalCloseButton" onClick={onClose}>x</button>
+          <h2 className="modalTitle">출판사 수정</h2>
+          <div className="formGroup"><input type="text" value={publisherName} onChange={e => setPublisherName(e.target.value)} /></div>
+          {message && <p className="errorMessage">{message}</p>}
+          <div className="modalFooter">
+                        <button onClick={onUpdateClick} className="">수정</button>
+                    </div>
 
-export default UpdatePublisher
+          </div></div>
+      )
+  }
+
+  export default UpdatePublisher;

--- a/bookhub-front/src/views/stock-logs/StockLogPage.tsx
+++ b/bookhub-front/src/views/stock-logs/StockLogPage.tsx
@@ -5,6 +5,7 @@ import { StockProps } from '@/components/types/StockProps';
 import StockLogdetail from './StockLogdetail';
 import { useCookies } from 'react-cookie';
 import { useEffect, useState } from 'react';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -89,7 +90,7 @@ function StockLogPage({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 로그</h2>
-      <div>
+      <div className='filter-bar'>
         <select className='input-search' value={type} onChange={(e) => setType(e.target.value as StockActionType)}>
           <option value=''>전체</option>
           <option value={StockActionType.IN}>입고</option>
@@ -127,7 +128,7 @@ function StockLogPage({ branches = [] }: StockProps) {
           검색
         </button>
         <div>
-          <table className=''>
+          <table className='table-policy'>
             <thead>
               <tr>
                 <th>IDX</th>
@@ -149,7 +150,7 @@ function StockLogPage({ branches = [] }: StockProps) {
                   <td>{s.amount}</td>
                   <td>{s.type}</td>
                   <td>
-                    <button className='' onClick={() => openDetailModal(s.stockLogId)}>
+                    <button className='modifyBtn' onClick={() => openDetailModal(s.stockLogId)}>
                       보기
                     </button>
                   </td>

--- a/bookhub-front/src/views/stock-logs/StockLogdetail.tsx
+++ b/bookhub-front/src/views/stock-logs/StockLogdetail.tsx
@@ -1,26 +1,26 @@
 import { StockLogResponseDto } from '@/dtos/stock/StockLog.response.dto';
-import React from 'react'
+import '@/styles/modal.css';
 
 interface StockLogProps{
     isOpen: boolean;
     onClose : () => void;
     stockLogDetail : StockLogResponseDto;
-    
 }
+
 function StockLogdetail({isOpen, onClose, stockLogDetail}:StockLogProps) {
   if(!isOpen) return null;
 
   return (
-        <div className="modal-overlay">
-            <div className="stockLog-detail-modal">
-                <button className="modal-close-button" onClick={onClose}>x</button>
-                <h2 className="modal-title">정책 상세 조회</h2>
-                <table className="detail-table">
-                    <tbody> 
+          <div className="modalOverlay">
+              <div className="modalContainer">
+                  <button className="modalCloseButton" onClick={onClose}>x</button>
+                  <h2 className="modalTitle">정책 상세 조회</h2>
+                  <table className="detailTable">
+                    <tbody>
                         <tr>
                             <th>지점</th>
                             <td>{stockLogDetail.branchName}</td>
-                        </tr>                                        
+                        </tr>
                         <tr>
                             <th>직원</th>
                             <td>{stockLogDetail.employeeName}</td>
@@ -41,7 +41,7 @@ function StockLogdetail({isOpen, onClose, stockLogDetail}:StockLogProps) {
                             <th>누적재고량</th>
                             <td>{stockLogDetail.bookAmount}</td>
                         </tr>
-                      
+
                         <tr>
                             <th>날짜</th>
                             <td>{stockLogDetail.actionDate}</td>
@@ -51,14 +51,14 @@ function StockLogdetail({isOpen, onClose, stockLogDetail}:StockLogProps) {
                             <th>설명</th>
                             <td>{stockLogDetail.description}</td>
                         </tr>
-    
+
                     </tbody>
-                    
+
                 </table>
-                
+
             </div>
         </div>
   );
 };
 
-export default StockLogdetail
+export default StockLogdetail;

--- a/bookhub-front/src/views/stocks/StockDetail.tsx
+++ b/bookhub-front/src/views/stocks/StockDetail.tsx
@@ -1,22 +1,22 @@
 
 import { StockResponseDto } from '@/dtos/stock/Stock.response.dto';
+import '@/styles/modal.css';
 
 interface StockDetailProps {
     isOpen: boolean;
     onClose : () => void;
     stockDetail : StockResponseDto;
-    
 }
 
-function PolicyDetail({isOpen, onClose, stockDetail}:StockDetailProps) {
+function StockDetail({isOpen, onClose, stockDetail}:StockDetailProps) {
   if(!isOpen) return null;
 
   return (
-    <div className="modal-overlay">
-        <div className="">
-            <button className="modal-close-button" onClick={onClose}>x</button>
-            <h2 className="modal-title">재고 상세 조회</h2>
-            <table className="detail-table">
+    <div className="modalOverlay">
+        <div className="modalContainer">
+            <button className="modalCloseButton" onClick={onClose}>x</button>
+            <h2 className="modalTitle">재고 상세 조회</h2>
+            <table className="detailTable">
                 <tbody>
                     <tr>
                         <th>책 제목</th>
@@ -43,4 +43,4 @@ function PolicyDetail({isOpen, onClose, stockDetail}:StockDetailProps) {
   );
 };
 
-export default PolicyDetail;
+export default StockDetail;

--- a/bookhub-front/src/views/stocks/StockPage.tsx
+++ b/bookhub-front/src/views/stocks/StockPage.tsx
@@ -4,6 +4,7 @@ import { StockResponseDto } from '@/dtos/stock/Stock.response.dto';
 import { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import StockUpdate from './StockUpdate';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -100,7 +101,7 @@ function StockPage({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 관리</h2>
-      <div className=''>
+      <div className='filter-bar'>
         <input
           className='input-search'
           type='text'

--- a/bookhub-front/src/views/stocks/StockSearch.tsx
+++ b/bookhub-front/src/views/stocks/StockSearch.tsx
@@ -4,6 +4,7 @@ import { StockResponseDto } from '@/dtos/stock/Stock.response.dto';
 import { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import StockDetail from './StockDetail';
+import '@/styles/style.css';
 
 const PAGE_SIZE = 10;
 
@@ -86,7 +87,7 @@ function StockSearch({ branches = [] }: StockProps) {
   return (
     <div>
       <h2>재고 검색</h2>
-      <div className=''>
+      <div className='filter-bar'>
         <input
           className='input-search'
           type='text'


### PR DESCRIPTION
## Summary
- style: add `modal.css` with global overlay, container, and form styles
- style: update policy, publisher, stock, and stock-log modals to use the global classes instead of CSS modules

## Testing
- `npm run lint`
- `npm run build` *(fails: unused variables in statistics components)*

------
https://chatgpt.com/codex/tasks/task_e_68917f8ae810832794d93bcbf3d2bacc